### PR TITLE
List domains and download catalog.

### DIFF
--- a/src/main/java/org/urban/data/provider/socrata/cli/Args.java
+++ b/src/main/java/org/urban/data/provider/socrata/cli/Args.java
@@ -60,6 +60,7 @@ public class Args {
     public final static String PARA_HTML = "html";
     public final static String PARA_ORDERBY = "orderby";
     public final static String PARA_OUTPUT = "output";
+    public final static String PARA_OVERWRITE = "overwrite";
     public final static String PARA_REPORT = "report";
     public final static String PARA_REVERSE = "reverse";
     public final static String PARA_STATS = "stats";
@@ -77,6 +78,7 @@ public class Args {
                 PARA_HTML,
                 PARA_ORDERBY,
                 PARA_OUTPUT,
+                PARA_OVERWRITE,
                 PARA_REPORT,
                 PARA_REVERSE,
                 PARA_STATS,
@@ -256,6 +258,15 @@ public class Args {
         }
     }
     
+    public boolean getOverwrite() {
+        
+        if (_parameters.containsKey(PARA_OVERWRITE)) {
+            return Boolean.parseBoolean(_parameters.get(PARA_OVERWRITE));
+        } else {
+            return false;
+        }
+    }
+   
     public boolean getReport() {
         
         if (_parameters.containsKey(PARA_REPORT)) {

--- a/src/main/java/org/urban/data/provider/socrata/cli/CommandImpl.java
+++ b/src/main/java/org/urban/data/provider/socrata/cli/CommandImpl.java
@@ -64,6 +64,8 @@ public abstract class CommandImpl implements Command {
                 _parameters.put(name, "Order by value of count");
             } else if (name.equals(Args.PARA_OUTPUT)) {
                 _parameters.put(name, "Output file");
+            } else if (name.equals(Args.PARA_OVERWRITE)) {
+                _parameters.put(name, "Overwrite existing file");
             } else if (name.equals(Args.PARA_REPORT)) {
                 _parameters.put(name, "Print actions but do not execute");
             } else if (name.equals(Args.PARA_REVERSE)) {

--- a/src/main/java/org/urban/data/provider/socrata/cli/DomainNames.java
+++ b/src/main/java/org/urban/data/provider/socrata/cli/DomainNames.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 New York University.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.urban.data.provider.socrata.cli;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import org.urban.data.core.query.JQuery;
+import org.urban.data.core.query.JsonQuery;
+import org.urban.data.core.query.ResultTuple;
+import org.urban.data.core.query.SelectClause;
+import org.urban.data.core.util.Counter;
+import org.urban.data.provider.socrata.db.DB;
+
+/**
+ * Query the catalog to get the names of all domains. Outputs the domain
+ * names sorted in alphabetical order together with the number of datasets.
+ * Also prints a summary with the total number of domains and datasets.
+ * 
+ * @author Heiko Mueller <heiko.mueller@nyu.edu>
+ */
+public class DomainNames extends CommandImpl implements Command {
+   
+    public DomainNames() {
+
+        super("domains", "Query catalog file for domain names");
+        this.addParameter(Args.PARA_DATE, "Date for catalog file (default: today)");
+    }
+
+    @Override
+    public void run(Args args) throws java.io.IOException {
+        
+        DB db = args.getDB();
+        String date = args.getDateDefaultLast();
+        
+        SelectClause select = new SelectClause()
+                .add("domain", new JQuery("/metadata/domain"));
+        
+        HashMap<String, Counter> domains = new HashMap<>();
+        
+        JsonQuery con = new JsonQuery(db.catalogFile(date));
+        for (ResultTuple tuple : con.executeQuery(select, true)) {
+        	String domain = tuple.getAsString("domain");
+        	if (domains.containsKey(domain)) {
+        		domains.get(domain).inc();
+        	} else {
+        		domains.put(domain, new Counter(1));
+        	}
+        }
+        
+        List<String> domainNames = new ArrayList<>(domains.keySet());
+        Collections.sort(domainNames);
+        
+        PrintWriter out = new PrintWriter(System.out);
+        out.println("Domains for catalog from " + date);
+        
+        int datasetCount = 0;
+        for (String domain : domainNames) {
+        	int datasets = domains.get(domain).value();
+        	out.println(String.format("%s\t%d", domain, datasets));
+        	datasetCount += datasets;
+        }
+        
+        out.println("\nSummary for catalog from " + date);
+        out.println(String.format("Total number of domains : %d", domainNames.size()));
+        out.println(String.format("Total number of datasets: %d", datasetCount));
+        out.flush();
+    }
+}

--- a/src/main/java/org/urban/data/provider/socrata/cli/DownloadCatalog.java
+++ b/src/main/java/org/urban/data/provider/socrata/cli/DownloadCatalog.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 New York University.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.urban.data.provider.socrata.cli;
+
+import java.io.File;
+import java.io.IOException;
+import org.urban.data.core.util.FileSystem;
+import org.urban.data.provider.socrata.SocrataCatalog;
+import org.urban.data.provider.socrata.db.DB;
+
+/**
+ * Download the current Socrata dataset catalog.
+ * 
+ * @author Heiko Mueller <heiko.mueller@nyu.edu>
+ */
+public class DownloadCatalog extends CommandImpl implements Command {
+
+    public DownloadCatalog() {
+
+        super("download catalog", "Download dataset catalog");
+        this.addParameter(Args.PARA_OVERWRITE, "Overwrite existing catalog file (default: false)");
+    }
+
+    @Override
+    public void run(Args args) throws IOException {
+        
+        DB db = args.getDB();
+        String date = args.getDateDefaultToday();
+        boolean overwrite = args.getOverwrite();
+        System.out.println(date);
+        System.out.println(overwrite);
+        
+        // Download the current Socrata catalog
+        File catalogFile = db.catalogFile(date);
+        if ((!catalogFile.exists()) || (overwrite)) {
+            FileSystem.createParentFolder(catalogFile);
+            new SocrataCatalog(catalogFile).download("dataset");
+        }
+    }
+}

--- a/src/main/java/org/urban/data/provider/socrata/cli/Socrata.java
+++ b/src/main/java/org/urban/data/provider/socrata/cli/Socrata.java
@@ -45,6 +45,7 @@ public class Socrata {
         new Clean(),
         new ColumnFinder(),
         new ColumnValues(),
+        new DomainNames(),
         new DownloadDates(),
         new DownloadDatasets(),
         new DiskUsage(),

--- a/src/main/java/org/urban/data/provider/socrata/cli/Socrata.java
+++ b/src/main/java/org/urban/data/provider/socrata/cli/Socrata.java
@@ -29,6 +29,7 @@ import static org.urban.data.provider.socrata.cli.Args.PARA_EXISTING;
 import static org.urban.data.provider.socrata.cli.Args.PARA_HTML;
 import static org.urban.data.provider.socrata.cli.Args.PARA_ORDERBY;
 import static org.urban.data.provider.socrata.cli.Args.PARA_OUTPUT;
+import static org.urban.data.provider.socrata.cli.Args.PARA_OVERWRITE;
 import static org.urban.data.provider.socrata.cli.Args.PARA_REPORT;
 import static org.urban.data.provider.socrata.cli.Args.PARA_REVERSE;
 import static org.urban.data.provider.socrata.cli.Args.PARA_STATS;
@@ -46,6 +47,7 @@ public class Socrata {
         new ColumnFinder(),
         new ColumnValues(),
         new DomainNames(),
+        new DownloadCatalog(),
         new DownloadDates(),
         new DownloadDatasets(),
         new DiskUsage(),
@@ -69,13 +71,14 @@ public class Socrata {
         PARA_EXISTING,
         PARA_HTML,
         PARA_ORDERBY,
+        PARA_OVERWRITE,
         PARA_REPORT,
         PARA_REVERSE,
         PARA_STATS,
         PARA_THREADS
     };
     
-    private static final String VERSION = "0.1.5";
+    private static final String VERSION = "0.1.6";
     
     private static HashMap<String, Command> commandListing() {
 


### PR DESCRIPTION
This PR addresses issues #1 and #2. It adds commands to the CLI that:

- list all domains and their dataset counts in a downloaded (existing) Socrata API catalog
- download the current Socrata API catalog